### PR TITLE
Fix prototype pollution in zip object deep

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -4129,11 +4129,14 @@
      *  into `array`.
      */
     function baseSortedIndexBy(array, value, iteratee, retHighest) {
-      value = iteratee(value);
-
       var low = 0,
-          high = array == null ? 0 : array.length,
-          valIsNaN = value !== value,
+          high = array == null ? 0 : array.length;
+      if (high === 0) {
+        return 0;
+      }
+
+      value = iteratee(value);
+      var valIsNaN = value !== value,
           valIsNull = value === null,
           valIsSymbol = isSymbol(value),
           valIsUndefined = value === undefined;

--- a/lodash.js
+++ b/lodash.js
@@ -5634,10 +5634,11 @@
       if (arrLength != othLength && !(isPartial && othLength > arrLength)) {
         return false;
       }
-      // Assume cyclic values are equal.
-      var stacked = stack.get(array);
-      if (stacked && stack.get(other)) {
-        return stacked == other;
+      // Check that cyclic values are equal.
+      var arrStacked = stack.get(array);
+      var othStacked = stack.get(other);
+      if (arrStacked && othStacked) {
+        return arrStacked == other && othStacked == array;
       }
       var index = -1,
           result = true,
@@ -5799,10 +5800,11 @@
           return false;
         }
       }
-      // Assume cyclic values are equal.
-      var stacked = stack.get(object);
-      if (stacked && stack.get(other)) {
-        return stacked == other;
+      // Check that cyclic values are equal.
+      var objStacked = stack.get(object);
+      var othStacked = stack.get(other);
+      if (objStacked && othStacked) {
+        return objStacked == other && othStacked == object;
       }
       var result = true;
       stack.set(object, other);

--- a/lodash.js
+++ b/lodash.js
@@ -3991,7 +3991,7 @@
             newValue = value;
 
         if (index != lastIndex) {
-          var objValue = nested[key];
+          var objValue = safeGet(nested, key);
           newValue = customizer ? customizer(objValue, key, nested) : undefined;
           if (newValue === undefined) {
             newValue = isObject(objValue)

--- a/lodash.js
+++ b/lodash.js
@@ -9916,15 +9916,15 @@
      * var users = [
      *   { 'user': 'fred',   'age': 48 },
      *   { 'user': 'barney', 'age': 36 },
-     *   { 'user': 'fred',   'age': 40 },
+     *   { 'user': 'fred',   'age': 30 },
      *   { 'user': 'barney', 'age': 34 }
      * ];
      *
      * _.sortBy(users, [function(o) { return o.user; }]);
-     * // => objects for [['barney', 36], ['barney', 34], ['fred', 48], ['fred', 40]]
+     * // => objects for [['barney', 36], ['barney', 34], ['fred', 48], ['fred', 30]]
      *
      * _.sortBy(users, ['user', 'age']);
-     * // => objects for [['barney', 34], ['barney', 36], ['fred', 40], ['fred', 48]]
+     * // => objects for [['barney', 34], ['barney', 36], ['fred', 30], ['fred', 48]]
      */
     var sortBy = baseRest(function(collection, iteratees) {
       if (collection == null) {

--- a/lodash.js
+++ b/lodash.js
@@ -9183,6 +9183,10 @@
      * // The `_.property` iteratee shorthand.
      * _.filter(users, 'active');
      * // => objects for ['barney']
+     *
+     * // Combining several predicates using `_.overEvery` or `_.overSome`.
+     * _.filter(users, _.overSome([{ 'age': 36 }, ['age', 40]]));
+     * // => objects for ['fred', 'barney']
      */
     function filter(collection, predicate) {
       var func = isArray(collection) ? arrayFilter : baseFilter;
@@ -15560,6 +15564,9 @@
      * values against any array or object value, respectively. See `_.isEqual`
      * for a list of supported value comparisons.
      *
+     * **Note:** Multiple values can be checked by combining several matchers
+     * using `_.overSome`
+     *
      * @static
      * @memberOf _
      * @since 3.0.0
@@ -15575,6 +15582,10 @@
      *
      * _.filter(objects, _.matches({ 'a': 4, 'c': 6 }));
      * // => [{ 'a': 4, 'b': 5, 'c': 6 }]
+     *
+     * // Checking for several possible values
+     * _.filter(users, _.overSome([_.matches({ 'a': 1 }), _.matches({ 'a': 4 })]));
+     * // => [{ 'a': 1, 'b': 2, 'c': 3 }, { 'a': 4, 'b': 5, 'c': 6 }]
      */
     function matches(source) {
       return baseMatches(baseClone(source, CLONE_DEEP_FLAG));
@@ -15588,6 +15599,9 @@
      * **Note:** Partial comparisons will match empty array and empty object
      * `srcValue` values against any array or object value, respectively. See
      * `_.isEqual` for a list of supported value comparisons.
+     *
+     * **Note:** Multiple values can be checked by combining several matchers
+     * using `_.overSome`
      *
      * @static
      * @memberOf _
@@ -15605,6 +15619,10 @@
      *
      * _.find(objects, _.matchesProperty('a', 4));
      * // => { 'a': 4, 'b': 5, 'c': 6 }
+     *
+     * // Checking for several possible values
+     * _.filter(users, _.overSome([_.matchesProperty('a', 1), _.matchesProperty('a', 4)]));
+     * // => [{ 'a': 1, 'b': 2, 'c': 3 }, { 'a': 4, 'b': 5, 'c': 6 }]
      */
     function matchesProperty(path, srcValue) {
       return baseMatchesProperty(path, baseClone(srcValue, CLONE_DEEP_FLAG));
@@ -15828,6 +15846,10 @@
      * Creates a function that checks if **all** of the `predicates` return
      * truthy when invoked with the arguments it receives.
      *
+     * Following shorthands are possible for providing predicates.
+     * Pass an `Object` and it will be used as an parameter for `_.matches` to create the predicate.
+     * Pass an `Array` of parameters for `_.matchesProperty` and the predicate will be created using them.
+     *
      * @static
      * @memberOf _
      * @since 4.0.0
@@ -15854,6 +15876,10 @@
      * Creates a function that checks if **any** of the `predicates` return
      * truthy when invoked with the arguments it receives.
      *
+     * Following shorthands are possible for providing predicates.
+     * Pass an `Object` and it will be used as an parameter for `_.matches` to create the predicate.
+     * Pass an `Array` of parameters for `_.matchesProperty` and the predicate will be created using them.
+     *
      * @static
      * @memberOf _
      * @since 4.0.0
@@ -15873,6 +15899,9 @@
      *
      * func(NaN);
      * // => false
+     *
+     * var matchesFunc = _.overSome([{ 'a': 1 }, { 'a': 2 }])
+     * var matchesPropertyFunc = _.overSome([['a', 1], ['a', 2]])
      */
     var overSome = createOver(arraySome);
 

--- a/lodash.js
+++ b/lodash.js
@@ -3719,8 +3719,21 @@
      * @returns {Array} Returns the new sorted array.
      */
     function baseOrderBy(collection, iteratees, orders) {
+      if (iteratees.length) {
+        iteratees = arrayMap(iteratees, function(iteratee) {
+          if (isArray(iteratee)) {
+            return function(value) {
+              return baseGet(value, iteratee.length === 1 ? iteratee[0] : iteratee);
+            }
+          }
+          return iteratee;
+        });
+      } else {
+        iteratees = [identity];
+      }
+
       var index = -1;
-      iteratees = arrayMap(iteratees.length ? iteratees : [identity], baseUnary(getIteratee()));
+      iteratees = arrayMap(iteratees, baseUnary(getIteratee()));
 
       var result = baseMap(collection, function(value, key, collection) {
         var criteria = arrayMap(iteratees, function(iteratee) {

--- a/test/test.js
+++ b/test/test.js
@@ -25787,6 +25787,14 @@
     });
   });
 
+  QUnit.test('`_.zipObjectDeep` should not pollute prototype when __proto__ passed', function(assert) {
+    assert.expect(1);
+
+    _.zipObjectDeep(['__proto__.x'], [123]);
+
+    assert.equal(typeof x, 'undefined');
+  });
+
   /*--------------------------------------------------------------------------*/
 
   QUnit.module('lodash.zipWith');

--- a/test/test.js
+++ b/test/test.js
@@ -16020,11 +16020,30 @@
       { 'a': 'y', 'b': 2 }
     ];
 
+    var nestedObj = [
+      { id: '4', address: { zipCode: 4, streetName: 'Beta' } },
+      { id: '3', address: { zipCode: 3, streetName: 'Alpha' } },
+      { id: '1', address: { zipCode: 1, streetName: 'Alpha' } },
+      { id: '2', address: { zipCode: 2, streetName: 'Alpha' } },
+      { id: '5', address: { zipCode: 4, streetName: 'Alpha' } },
+    ];
+
     QUnit.test('should sort by a single property by a specified order', function(assert) {
       assert.expect(1);
 
       var actual = _.orderBy(objects, 'a', 'desc');
       assert.deepEqual(actual, [objects[1], objects[3], objects[0], objects[2]]);
+    });
+
+    QUnit.test('should sort by nested key in array format', function(assert) {
+      assert.expect(1);
+
+      var actual = _.orderBy(
+        nestedObj,
+        [['address', 'zipCode'], ['address.streetName']],
+        ['asc', 'desc'],
+      );
+      assert.deepEqual(actual, [nestedObj[2], nestedObj[3], nestedObj[1], nestedObj[0], nestedObj[4]]);
     });
 
     QUnit.test('should sort by multiple properties by specified orders', function(assert) {

--- a/test/test.js
+++ b/test/test.js
@@ -9741,7 +9741,7 @@
     });
 
     QUnit.test('should compare arrays with circular references', function(assert) {
-      assert.expect(4);
+      assert.expect(6);
 
       var array1 = [],
           array2 = [];
@@ -9766,6 +9766,14 @@
       array2 = ['a', ['a', 'b', 'c'], 'c'];
 
       assert.strictEqual(_.isEqual(array1, array2), false);
+
+      array1 = [[[]]];
+      array1[0][0][0] = array1;
+      array2 = [];
+      array2[0] = array2;
+
+      assert.strictEqual(_.isEqual(array1, array2), false);
+      assert.strictEqual(_.isEqual(array2, array1), false);
     });
 
     QUnit.test('should have transitive equivalence for circular references of arrays', function(assert) {
@@ -9783,7 +9791,7 @@
     });
 
     QUnit.test('should compare objects with circular references', function(assert) {
-      assert.expect(4);
+      assert.expect(6);
 
       var object1 = {},
           object2 = {};
@@ -9808,6 +9816,14 @@
       object2 = { 'a': 1, 'b': { 'a': 1, 'b': 2, 'c': 3 }, 'c': 3 };
 
       assert.strictEqual(_.isEqual(object1, object2), false);
+
+      object1 = {self: {self: {self: {}}}};
+      object1.self.self.self = object1;
+      object2 = {self: {}};
+      object2.self = object2; 
+
+      assert.strictEqual(_.isEqual(object1, object2), false);
+      assert.strictEqual(_.isEqual(object2, object1), false);
     });
 
     QUnit.test('should have transitive equivalence for circular references of objects', function(assert) {

--- a/test/test.js
+++ b/test/test.js
@@ -20998,6 +20998,16 @@
       assert.strictEqual(actual, 1);
     });
 
+    QUnit.test('`_.' + methodName + '` should avoid calling iteratee when length is 0', function(assert) {
+      var objects = [],
+          iteratee = function() {
+            throw new Error;
+          },
+          actual = func(objects, { 'x': 50 }, iteratee);
+
+      assert.strictEqual(actual, 0);
+    });
+
     QUnit.test('`_.' + methodName + '` should support arrays larger than `MAX_ARRAY_LENGTH / 2`', function(assert) {
       assert.expect(12);
 


### PR DESCRIPTION
This fixes a security [issue](https://snyk.io/vuln/npm:lodash@4.17.15). The maintainers of [lodash](https://github.com/lodash/lodash) are [reluctant](https://github.com/lodash/lodash/pull/4745) to merge this in to their repo, so I've branched off of their [4.15.17](https://github.com/lodash/lodash/releases/tag/4.17.15) tag, and applied the [patch](https://github.com/lodash/lodash/pull/4745).